### PR TITLE
Channel Delete Functionality

### DIFF
--- a/src/App/components/SideBar.js
+++ b/src/App/components/SideBar.js
@@ -5,26 +5,33 @@ import {
 } from 'reactstrap';
 import NavBar from './NavBar';
 import { signInUser, signOutUser } from '../../helpers/auth';
+// import { deleteChannel } from '../../helpers/data/channelsData';
+// import { deleteChannel } from '../../helpers/data/channelsData';
 
-const handleClick = () => {
+const getChannelLinks = (channels) => {
+  const handleButtonClick = (channelID) => {
+    // deleteChannel(channelID);
+    console.warn(channelID);
+  };
 
-}
-const getChannels = (channels) => (
-  <>
-
+  return (
+    <>
     {
-     channels.map((channelInfo, key) => (
-       <NavItem key={key}
-       firebaseKey={channelInfo.channelId}
-       >
-         <NavLink >{channelInfo.channelName}</NavLink>
-         <Button color="danger" onClick={handleClick}> Delete Channel </Button>
-       </NavItem>
-     ))
-    }
+    channels.map((channelInfo) => (
+  <NavItem key={channelInfo.channelID}>
+    <NavLink >{channelInfo.channelName}
+     <Button style={{ backgroundColor: 'transparent', borderWidth: '0rem' }} onClick={handleButtonClick(channelInfo.channelID)}>
+     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" className="bi bi-trash" viewBox="0 0 16 16">
+       <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+       <path fillRule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+     </svg>
+     </Button>
+    </NavLink>
+  </NavItem>))
+}
   </>
-);
-
+  );
+};
 const getUsers = (usersArray) => (
   <>
     {
@@ -60,7 +67,7 @@ function SideBar({ user, channels, usersArray }) {
         }
       <h4>Channels</h4>
         </NavItem>
-        {user && getChannels(channels)}
+        {user && getChannelLinks(channels)}
       </Nav>
       <hr />
       <div className ="usersSideNav"></div>
@@ -79,4 +86,4 @@ SideBar.propTypes = {
   usersArray: PropTypes.array
 };
 
-export default SideBar;
+export { SideBar, getChannelLinks };

--- a/src/App/components/SideBar.js
+++ b/src/App/components/SideBar.js
@@ -48,7 +48,7 @@ function SideBar({
                     viewBox="0 0 16 16">
                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" viewBox="0 0 16 16">
                     <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
-                    <path fillrule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                    <path fillRule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
                     </svg>
                   </svg>
                </Button>

--- a/src/App/components/SideBar.js
+++ b/src/App/components/SideBar.js
@@ -50,14 +50,11 @@ function SideBar({
                     fill="black"
                     className="bi bi-trash"
                     viewBox="0 0 16 16">
-                   <path
-                     d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.    5zm3 . 5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"
-                    />
-                   <path
-                     fillRule="evenodd"
-                     d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0     0 1      1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5     3V2h11v1h-11z"
-                    />
-                 </svg>
+                   <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="black" viewBox="0 0 16 16">
+                    <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/>
+                    <path fillrule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/>
+                    </svg>
+                  </svg>
                </Button>
               </NavLink>
             </NavItem>))

--- a/src/App/components/SideBar.js
+++ b/src/App/components/SideBar.js
@@ -6,12 +6,19 @@ import {
 import NavBar from './NavBar';
 import { signInUser, signOutUser } from '../../helpers/auth';
 
+const handleClick = () => {
+
+}
 const getChannels = (channels) => (
   <>
+
     {
      channels.map((channelInfo, key) => (
-       <NavItem key={key}>
+       <NavItem key={key}
+       firebaseKey={channelInfo.channelId}
+       >
          <NavLink >{channelInfo.channelName}</NavLink>
+         <Button color="danger" onClick={handleClick}> Delete Channel </Button>
        </NavItem>
      ))}
   </>

--- a/src/App/components/SideBar.js
+++ b/src/App/components/SideBar.js
@@ -5,7 +5,6 @@ import {
   Nav, NavbarToggler, NavItem, NavLink, Button
 } from 'reactstrap';
 import { signInUser, signOutUser } from '../../helpers/auth';
-// import { deleteChannel } from '../../helpers/data/channelsData';
 import { deleteChannel } from '../../helpers/data/channelsData';
 
 const getUsers = (usersArray) => (
@@ -26,11 +25,8 @@ function SideBar({
   const [isOpen, setIsOpen] = useState(false);
   const toggle = () => setIsOpen(!isOpen);
   const getChannelLinks = () => {
-    // console.warn(setChannels(channels));
     const handleButtonClick = (channelID) => {
-      // deleteChannel(channelID);
       deleteChannel(channelID).then(setChannels);
-      // console.warn(channelID);
     };
     return (
       <>

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import firebase from 'firebase/app';
 import 'firebase/auth';
-import SideBar from './components/SideBar';
+import { SideBar } from './components/SideBar';
 import './App.scss';
-import getChannels from '../helpers/data/channelsData';
+import { getChannels } from '../helpers/data/channelsData';
 import getUsers from '../helpers/data/usersData';
 
 function App() {

--- a/src/helpers/data/channelsData.js
+++ b/src/helpers/data/channelsData.js
@@ -9,4 +9,5 @@ const getChannels = () => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
+// const deleteChannel = ()
 export default getChannels;

--- a/src/helpers/data/channelsData.js
+++ b/src/helpers/data/channelsData.js
@@ -9,5 +9,9 @@ const getChannels = () => new Promise((resolve, reject) => {
     .catch((error) => reject(error));
 });
 
-// const deleteChannel = ()
-export default getChannels;
+const deleteChannel = (channelID) => new Promise((resolve, reject) => {
+  axios.delete(`${dbURL}/channels/${channelID}.json`)
+    .then(() => getChannels().then((channelArray) => resolve(channelArray)))
+    .catch((error) => reject(error));
+});
+export { getChannels, deleteChannel };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A delete button (trash can) is dynamically rendering next to each channel. 
When this button is clicked, it deletes the channel and all its info (messages, users, etc)
It then re-renders the DOM with the updated list of channels



## Description
 - Added a Delete button to each channel dynamically in the channel Map Function. 
 - When clicked, the channel and all of its info is deleted from the Dom and Firebase. 
 - The Dom is then re-built with the most updated channels

## Related Issue
#23 

## Motivation and Context
This was needed to be able for the User to delete created channels and all of the info associated with the channel. 

## How Can This Be Tested?
It can be tested by pressing the Trash Can button next to the associated channel on the sidebar

## Screenshots (if appropriate):
![Delete](https://user-images.githubusercontent.com/76926244/118374874-bb246580-b583-11eb-9134-0e42aecce96a.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
